### PR TITLE
Add Pelican

### DIFF
--- a/oidc-applications.json
+++ b/oidc-applications.json
@@ -1168,6 +1168,17 @@
       "license": "AGPL-3.0",
       "description": "A self-hosted Linux patch management and fleet automation platform with OpenID Connect single sign-on, including automatic user provisioning, group-to-role mapping, and SSO-only enforcement.",
       "documentation_url": "https://docs.patchmon.net/docs/patchmon-admin-guide#oidc--sso"
+    },
+    {
+      "name": "Pelican",
+      "category": "Game server management",
+      "oidc_status": "extension",
+      "project_url": "https://pelican.dev/",
+      "github_url": "https://github.com/pelican/panel",
+      "logo_url": "https://raw.githubusercontent.com/pelican/panel/main/public/pelican.svg",
+      "license": "AGPL-3.0",
+      "description": "A self-hosted game server management panel with free OAuth login and a first-party generic OIDC plugin that supports any custom OpenID Connect provider.",
+      "documentation_url": "https://github.com/pelican/plugins/tree/main/generic-oidc-providers"
     }
   ]
 }


### PR DESCRIPTION
Adds Pelican (https://pelican.dev), a self-hosted game server management panel. OAuth login is free in core, and the first-party generic-oidc-providers plugin (https://github.com/pelican/plugins/tree/main/generic-oidc-providers) adds support for any custom OIDC provider, so this is marked as extension status. Verified the site builds locally with the new entry and category.