### PR TITLE
Add K7

### DIFF
--- a/oidc-applications.json
+++ b/oidc-applications.json
@@ -1257,6 +1257,16 @@
       "license": "AGPL-3.0",
       "description": "A self-hosted game server management panel with free OAuth login and a first-party generic OIDC plugin that supports any custom OpenID Connect provider.",
       "documentation_url": "https://github.com/pelican/plugins/tree/main/generic-oidc-providers"
+    },
+    {
+      "name": "K7",
+      "category": "Media streaming",
+      "project_url": "https://k7.kaybi.dev",
+      "github_url": "https://github.com/kaybi-gh/K7",
+      "logo_url": "https://raw.githubusercontent.com/kaybi-gh/K7/main/branding/symbol-on-light.svg",
+      "license": "AGPL-3.0",
+      "description": "A self-hosted media server for movies, TV, and music with built-in OpenID Connect login, optional automatic account creation, and explicit account linking.",
+      "documentation_url": "https://github.com/kaybi-gh/K7/blob/main/docs/admin/configuration.md#oidc--sso"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add K7, a self-hosted media server with built-in OIDC login

## Test plan
- [x] Docs link opens the OIDC section
- [x] Symbol logo renders on the catalog