### PR TITLE
Dockhand: MFA is free, not an Enterprise add-on

### DIFF
--- a/oidc-applications.json
+++ b/oidc-applications.json
@@ -1176,7 +1176,7 @@
       "github_url": "https://github.com/Finsys/dockhand",
       "logo_url": "https://raw.githubusercontent.com/Finsys/dockhand/main/static/favicon-32x32.png",
       "license": "BSL-1.1",
-      "description": "A self-hosted Docker management platform with OIDC/SSO login included free in every tier (LDAP, MFA, and RBAC are the paid Enterprise add-ons), though its BSL 1.1 license is not open source.",
+      "description": "A self-hosted Docker management platform with OIDC/SSO login and MFA included free in every tier (LDAP and RBAC are the paid Enterprise add-ons), though its BSL 1.1 license is not open source.",
       "documentation_url": "https://dockhand.pro/manual#appendix-oidc"
     },
     {


### PR DESCRIPTION
## Correct Dockhand entry: MFA is free, not an Enterprise add-on

Disclosure: I'm the maintainer of Dockhand.

The current Dockhand entry lists **MFA** among the paid Enterprise add-ons. That's not accurate. MFA (TOTP two-factor auth) is available to **every** user on all tiers, free included - it's plain self-service under a user's profile and is not gated by the license.

The features that are genuinely Enterprise-only are **LDAP** and **RBAC**. SSO/OIDC and MFA are free.

This PR updates the description accordingly:

> before: `...OIDC/SSO login included free in every tier (LDAP, MFA, and RBAC are the paid Enterprise add-ons)...`
> after: `...OIDC/SSO login and MFA included free in every tier (LDAP and RBAC are the paid Enterprise add-ons)...`

Everything else in the entry (BSL 1.1 license note, links) is unchanged.
